### PR TITLE
Plot 1D profiles in horizontal plot

### DIFF
--- a/examples/32_plot_velocity_deficit_profiles.py
+++ b/examples/32_plot_velocity_deficit_profiles.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from floris.tools import FlorisInterface
 from floris.tools.visualization import VelocityProfilesFigure
-
+import floris.tools.visualization as wakeviz
 
 """
 The first part of this example illustrates how to plot velocity deficit profiles at
@@ -37,16 +37,18 @@ def get_profiles(direction, resolution=100):
         downstream_dists=downstream_dists,
         resolution=resolution,
         homogeneous_wind_speed=homogeneous_wind_speed,
+        wind_direction=wind_direction
     )
 
 if __name__ == '__main__':
     D = 126.0 # Turbine diameter
     hub_height = 90.0
     fi = FlorisInterface("inputs/gch.yaml")
-    fi.reinitialize(layout_x=[0.0], layout_y=[0.0])
+    fi.reinitialize(layout_x=[0.0, 500, 1000], layout_y=[0.0, 0.0, 0.0])
 
     downstream_dists = D * np.array([3, 5, 7])
     homogeneous_wind_speed = 8.0
+    wind_direction = 310
 
     # Below, `get_profiles('y')` returns three velocity deficit profiles. These are sampled along
     # three corresponding lines that are all parallel to the y-axis (cross-stream direction).
@@ -55,6 +57,13 @@ if __name__ == '__main__':
     # same streamwise locations.
     profiles = get_profiles('y') + get_profiles('z')
 
+    plane = fi.calculate_horizontal_plane(height=90,  wd=[wind_direction])
+    ax = wakeviz.visualize_cut_plane(plane)
+    colors = ['r', 'g', 'b', 'c', 'm', 'y']
+    for i, prof in enumerate(profiles):
+        ax.plot(prof['x'], prof['y'], colors[i], label=str(i))
+    ax.legend()
+    
     # Initialize a VelocityProfilesFigure. The workflow is similar to a matplotlib Figure:
     # Initialize it, plot data, and then customize it further if needed.
     # The provided value of `layout` puts y-profiles on the top row of the figure and

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -429,6 +429,8 @@ class Floris(BaseClass):
         for i in range(n_lines):
             df = pd.DataFrame(
                 {
+                    "x": x_rotated[i],
+                    "y": y_rotated[i],
                     "x/D": x_relative_start[i]/ref_rotor_diameter,
                     "y/D": y_relative_start[i]/ref_rotor_diameter,
                     "z/D": z_relative_start[i]/ref_rotor_diameter,

--- a/floris/simulation/floris.py
+++ b/floris/simulation/floris.py
@@ -378,12 +378,15 @@ class Floris(BaseClass):
         # Rotate sample coordinates with the wind direction
         x_rotated, y_rotated, z_rotated = reverse_rotate_coordinates_rel_west(
             self.flow_field.wind_directions,
-            x[None, None, None, :, :],
-            y[None, None, None, :, :],
-            z[None, None, None, :, :],
+            x[None, :, :],
+            y[None, :, :],
+            z[None, :, :],
             x_center_of_rotation=x_start,
             y_center_of_rotation=y_start,
         )
+        x_rotated = np.squeeze(x_rotated, axis=0)
+        y_rotated = np.squeeze(y_rotated, axis=0)
+        z_rotated = np.squeeze(z_rotated, axis=0)
 
         field_grid = PointsGrid(
             points_x=x_rotated.flatten(),

--- a/floris/tools/visualization.py
+++ b/floris/tools/visualization.py
@@ -312,7 +312,7 @@ def visualize_cut_plane(
     # Make equal axis
     ax.set_aspect("equal")
 
-    return im
+    return ax
 
 
 def visualize_heterogeneous_cut_plane(

--- a/floris/utilities.py
+++ b/floris/utilities.py
@@ -303,9 +303,9 @@ def reverse_rotate_coordinates_rel_west(
     grid_y_reversed = np.zeros_like(grid_x)
     grid_z_reversed = np.zeros_like(grid_x)
     for wii, angle_rotation in enumerate(wind_deviation_from_west):
-        x_rot = grid_x[wii, :, :, :, :]
-        y_rot = grid_y[wii, :, :, :, :]
-        z_rot = grid_z[wii, :, :, :, :]
+        x_rot = grid_x[wii]
+        y_rot = grid_y[wii]
+        z_rot = grid_z[wii]
 
         # Rotate turbine coordinates about the center
         x_rot_offset = x_rot - x_center_of_rotation
@@ -322,9 +322,9 @@ def reverse_rotate_coordinates_rel_west(
         )
         z = z_rot  # Nothing changed in this rotation
 
-        grid_x_reversed[wii, :, :, :, :] = x
-        grid_y_reversed[wii, :, :, :, :] = y
-        grid_z_reversed[wii, :, :, :, :] = z
+        grid_x_reversed[wii] = x
+        grid_y_reversed[wii] = y
+        grid_z_reversed[wii] = z
 
     return grid_x_reversed, grid_y_reversed, grid_z_reversed
 


### PR DESCRIPTION

This pull request adds lines to a `horizontal_plane` plot to show where in the farm the 1D lines are located.

@vallbog note this is still a work in progress, but I wanted to let you know what I'm looking at. I'd like to add this bit of clarity in the example so we know what to expect from the wake profile.

Related to https://github.com/NREL/floris/pull/699.

As an aside, this does provide an important fix to the `floris.utilities.reverse_rotate_coordinates_rel_west` so that it supports an arbitrary number of dimensions rather than requiring 5-dimensional arrays. That function will still require a leading dimension for "wind directions" in the arrays, but this is straightforward to handle by adding a dummy dimension and then removing it:

```python
# Adds the dummy dimension of size 0
x[None, :, :],

# Call floris.utilities.reverse_rotate_coordinates_rel_west -> returns x_rotated

# Remove the dummy dimension
x_rotated = np.squeeze(x_rotated, axis=0)
```